### PR TITLE
Fix AppBarStateChangeListener 引起的内存泄漏

### DIFF
--- a/library/src/main/java/com/liaoinstan/springview/widget/SpringView.java
+++ b/library/src/main/java/com/liaoinstan/springview/widget/SpringView.java
@@ -137,7 +137,7 @@ public class SpringView extends ViewGroup {
         }
     }
 
-    public SpringView( Context context) {
+    public SpringView(Context context) {
         this(context, null);
     }
 

--- a/library/src/main/java/com/liaoinstan/springview/widget/SpringView.java
+++ b/library/src/main/java/com/liaoinstan/springview/widget/SpringView.java
@@ -104,6 +104,7 @@ public class SpringView extends ViewGroup {
     private RecyclerView.OnScrollListener onRecyclerScrollListener;
     private NestedScrollView.OnScrollChangeListener onNestedScrollChangeListener;
     private OnScrollChangeListener onScrollChangeListener;
+    private AppBarStateChangeListener appBarStateChangeListener;
 
     @Override
     protected void onAttachedToWindow() {
@@ -112,16 +113,31 @@ public class SpringView extends ViewGroup {
         AppBarLayout appBarLayout = SpringHelper.findAppBarLayout(this);
         appBarCouldScroll = SpringHelper.couldScroll(appBarLayout);
         if (appBarLayout != null) {
-            appBarLayout.addOnOffsetChangedListener(new AppBarStateChangeListener() {
-                @Override
-                public void onStateChanged(AppBarLayout appBarLayout, State state) {
-                    appbarState = state;
-                }
-            });
+            if (appBarStateChangeListener == null) {
+                appBarStateChangeListener = new AppBarStateChangeListener() {
+                    @Override
+                    public void onStateChanged(AppBarLayout appBarLayout, State state) {
+                        appbarState = state;
+                    }
+                };
+            }
+            appBarLayout.addOnOffsetChangedListener(appBarStateChangeListener);
         }
     }
 
-    public SpringView(Context context) {
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        //解决ViewPager更新内容时出现的内存泄漏
+        if (appBarStateChangeListener != null) {
+            AppBarLayout appBarLayout = SpringHelper.findAppBarLayout(this);
+            if (appBarLayout != null) {
+                appBarLayout.removeOnOffsetChangedListener(appBarStateChangeListener);
+            }
+        }
+    }
+
+    public SpringView( Context context) {
         this(context, null);
     }
 


### PR DESCRIPTION
在TabLayout+ViewPager+Fragment使用场景时，重新设置TabLayout和ViewPager会出现内存泄漏，在SpringView的onDetachFromWindow()方法移除AppBarLayout的OnOffsetChangedListener。